### PR TITLE
UI-9 Trigger update event if current load's query and last load's query are same

### DIFF
--- a/js/collection.js
+++ b/js/collection.js
@@ -207,12 +207,17 @@ define([
             if (!reload) {
                 if (self._lastLoad && self._lastLoad.query === self.query &&
                     _.isEqual(self._lastLoad.params, params)) {
-                    /*self._lastLoad.dfd.done(function(models){
-                        // the deferred resolves but since there is no update event fired,
-                        // components subscribing to the collection are not notified that
-                        // the deferred has actually resolved
+                   
+                    // check if a request is pending, if so just return the deferred and update
+                    // later when resolved
+                    if(self._lastLoad.dfd.state() !== 'pending') {
+                        // lifted this logic from the `page cache` section below
+                        models = self.models;
+                        limit = params.limit;
+                        offset = params.offset;
+                        models = (limit) ? models.slice(offset, offset + limit) : models.slice(offset);
                         self.trigger('update', self, models);
-                    });*/
+                    }
                     return self._lastLoad.dfd;
                 }
             }

--- a/js/collection.js
+++ b/js/collection.js
@@ -207,12 +207,12 @@ define([
             if (!reload) {
                 if (self._lastLoad && self._lastLoad.query === self.query &&
                     _.isEqual(self._lastLoad.params, params)) {
-                    self._lastLoad.dfd.done(function(models){
+                    /*self._lastLoad.dfd.done(function(models){
                         // the deferred resolves but since there is no update event fired,
                         // components subscribing to the collection are not notified that
                         // the deferred has actually resolved
                         self.trigger('update', self, models);
-                    });
+                    });*/
                     return self._lastLoad.dfd;
                 }
             }

--- a/js/collection.js
+++ b/js/collection.js
@@ -233,7 +233,16 @@ define([
                 // the objects we have are valid cached objects
                 models = (limit) ? models.slice(offset, offset + limit) : models.slice(offset);
                 // underflow may happen on limit changes
-                underflow = ((offset + limit) <= total) && (models.length !== limit);
+                if((offset + limit) <= total) {
+                    underflow = models.length < limit;
+                }else {
+                     /*underflow corner case - in the final window, grid queries for more records than 
+                       available in total but cache does not hold all the remaining records, can (should) 
+                       be a ternary statement but for now sticking to an if-else 
+                       to understand better when working on this later :(
+                    */
+                    underflow = (total - offset) !== models.length;
+                }
 
                 // check to make sure the models are valid and not just empty
                 // remove falsy values i.e. undefined and check if the length is still the same


### PR DESCRIPTION
Triggered the update event inside collection.load even if current load's query is the same as the previous load's. This would allow grid components with paging/infinite scroll enabled to update their view based on the collection change.
